### PR TITLE
Updates method call chaining to 'if long'

### DIFF
--- a/configs/codestyles/PixiteAndroid.xml
+++ b/configs/codestyles/PixiteAndroid.xml
@@ -415,7 +415,7 @@
     <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
     <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
     <option name="EXTENDS_LIST_WRAP" value="5" />
-    <option name="METHOD_CALL_CHAIN_WRAP" value="2" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
     <option name="ASSIGNMENT_WRAP" value="1" />
     <option name="METHOD_ANNOTATION_WRAP" value="1" />
     <option name="FIELD_ANNOTATION_WRAP" value="1" />


### PR DESCRIPTION
This updates the call chaining setting to 'if long' so that short chained calls don't **need** to be wrapped.

Original:

```
assertThat(event.name)
  .isEqualTo("no params")
```

New:

```
assertThat(event.name).isEqualTo("no params")
```